### PR TITLE
feat: add scrollbar widgets for position feedback

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
+use ratatui::widgets::ScrollbarState;
 use ratatui_explorer::FileExplorer;
 
 use crate::editor::History;
@@ -173,6 +174,12 @@ pub struct App {
     pub(crate) selection_anchor: Option<(usize, usize)>,
     /// Clipboard for yanked block (rectangular selection).
     pub(crate) clipboard: Option<Vec<Vec<char>>>,
+
+    // === Scrollbar state ===
+    /// Vertical scrollbar state (kept in sync with viewport).
+    pub(crate) v_scrollbar_state: ScrollbarState,
+    /// Horizontal scrollbar state (kept in sync with viewport).
+    pub(crate) h_scrollbar_state: ScrollbarState,
 }
 
 impl Default for App {
@@ -212,6 +219,8 @@ impl Default for App {
             file_explorer: None,
             selection_anchor: None,
             clipboard: None,
+            v_scrollbar_state: ScrollbarState::default(),
+            h_scrollbar_state: ScrollbarState::default(),
         }
     }
 }
@@ -1125,5 +1134,16 @@ impl App {
         } else if self.cursor_col >= self.viewport_col + visible_cols {
             self.viewport_col = self.cursor_col - visible_cols + 1;
         }
+    }
+
+    /// Update scrollbar state to reflect current viewport position.
+    pub fn update_scrollbar_state(&mut self, visible_rows: usize, visible_cols: usize) {
+        self.v_scrollbar_state = ScrollbarState::new(self.alignment.num_sequences())
+            .position(self.viewport_row)
+            .viewport_content_length(visible_rows);
+
+        self.h_scrollbar_state = ScrollbarState::new(self.alignment.width())
+            .position(self.viewport_col)
+            .viewport_content_length(visible_cols);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,9 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
         // Adjust viewport to keep cursor visible
         app.adjust_viewport(visible_rows, visible_cols);
 
+        // Update scrollbar state to reflect current position
+        app.update_scrollbar_state(visible_rows, visible_cols);
+
         // Draw UI
         terminal.draw(|f| ui::render(f, app))?;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,17 +3,17 @@
 
 use ratatui::{
     Frame,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Block, Borders, Clear, Paragraph, Scrollbar, ScrollbarOrientation},
 };
 
 use crate::app::{ActivePane, App, ColorScheme, Mode, SplitMode};
 use crate::color::get_color;
 
 /// Render the application UI.
-pub fn render(frame: &mut Frame, app: &App) {
+pub fn render(frame: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -161,7 +161,7 @@ impl IdFormatter {
 /// Render an alignment pane with the given viewport.
 fn render_alignment_pane(
     frame: &mut Frame,
-    app: &App,
+    app: &mut App,
     area: Rect,
     viewport_row: usize,
     viewport_col: usize,
@@ -355,6 +355,33 @@ fn render_alignment_pane(
 
         let ss_line = Paragraph::new(Line::from(spans));
         frame.render_widget(ss_line, ss_cons_area);
+    }
+
+    // Render scrollbars (only in active pane to avoid confusion)
+    if is_active {
+        // Vertical scrollbar (right side of inner area)
+        let v_scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .begin_symbol(Some("▲"))
+            .end_symbol(Some("▼"))
+            .track_symbol(Some("│"))
+            .thumb_symbol("█");
+        frame.render_stateful_widget(
+            v_scrollbar,
+            inner.inner(Margin { vertical: 0, horizontal: 0 }),
+            &mut app.v_scrollbar_state,
+        );
+
+        // Horizontal scrollbar (bottom of inner area)
+        let h_scrollbar = Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
+            .begin_symbol(Some("◀"))
+            .end_symbol(Some("▶"))
+            .track_symbol(Some("─"))
+            .thumb_symbol("█");
+        frame.render_stateful_widget(
+            h_scrollbar,
+            inner.inner(Margin { vertical: 0, horizontal: 0 }),
+            &mut app.h_scrollbar_state,
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

- Add vertical and horizontal scrollbars using ratatui's Scrollbar widget
- Scrollbars show current viewport position in large alignments
- Only rendered in active pane (avoids confusion in split mode)
- State automatically syncs with viewport position

## Visual Features

- Vertical scrollbar: `▲`/`▼` arrows, `│` track, `█` thumb
- Horizontal scrollbar: `◀`/`▶` arrows, `─` track, `█` thumb

## Test plan

- [ ] Load a large alignment file
- [ ] Verify scrollbars appear and reflect position
- [ ] Navigate with hjkl/arrow keys and verify scrollbar updates
- [ ] Test in split mode - only active pane shows scrollbars

🤖 Generated with [Claude Code](https://claude.com/claude-code)