### PR TITLE
Adopt ratatui ecosystem widgets (scrollbars, list, input)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ kodama = "0.3"
 termbg = "0.6"
 flate2 = "1.1"
 strum = { version = "0.27", features = ["derive"] }
+tui-input = { version = "0.15.3", features = ["ratatui-crossterm"] }
 
 [profile.release]
 lto = true

--- a/src/app.rs
+++ b/src/app.rs
@@ -41,20 +41,6 @@ impl SearchState {
         !self.matches.is_empty() && !self.pattern.is_empty()
     }
 
-    /// Navigate to previous history entry.
-    pub fn history_prev(&mut self) {
-        if let Some(entry) = self.history.prev(&self.pattern) {
-            self.pattern = entry.to_string();
-        }
-    }
-
-    /// Navigate to next history entry.
-    pub fn history_next(&mut self) {
-        if let Some(entry) = self.history.next() {
-            self.pattern = entry.to_string();
-        }
-    }
-
     /// Check if a position is part of a search match.
     /// Returns Some(true) if it's the current match, Some(false) if it's another match, None if not a match.
     pub fn is_match(&self, row: usize, col: usize) -> Option<bool> {
@@ -178,6 +164,8 @@ pub struct App {
     pub color_scheme: ColorScheme,
     /// Show help overlay.
     pub show_help: bool,
+    /// Scroll offset (in lines) for the help overlay.
+    pub(crate) help_scroll: u16,
     /// Show position ruler at top.
     pub show_ruler: bool,
     /// Show row numbers.
@@ -192,8 +180,9 @@ pub struct App {
     pub active_pane: ActivePane,
 
     // === Crate-internal ===
-    /// Command line buffer (for command mode).
-    pub(crate) command_buffer: String,
+    /// Shared line-editing buffer for command (`:`) and search (`/`) modes.
+    /// These modes are never active simultaneously, so a single input suffices.
+    pub(crate) line_input: tui_input::Input,
     /// Should quit.
     pub(crate) should_quit: bool,
 
@@ -287,6 +276,8 @@ pub struct App {
     // === Info overlay ===
     /// Show file info overlay.
     pub show_info: bool,
+    /// Scroll offset (in lines) for the info overlay.
+    pub(crate) info_scroll: u16,
 
     // === Multiple alignments ===
     /// All alignments loaded from the current file (a Stockholm file may hold
@@ -324,7 +315,7 @@ impl Default for App {
             viewport_row: 0,
             viewport_col: 0,
             mode: Mode::Normal,
-            command_buffer: String::new(),
+            line_input: tui_input::Input::default(),
             command_history: InputHistory::new(),
             search: SearchState::new(),
             completion: None,
@@ -336,6 +327,7 @@ impl Default for App {
             history: History::new(),
             should_quit: false,
             show_help: false,
+            help_scroll: 0,
             show_ruler: true,
             show_row_numbers: true,
             show_short_ids: false,
@@ -369,6 +361,7 @@ impl Default for App {
             show_pp_cons: false,
             consensus_threshold: 0.7,
             show_info: false,
+            info_scroll: 0,
             alignments: Vec::new(),
             current_alignment: 0,
             show_msa_picker: false,
@@ -817,20 +810,20 @@ impl App {
     /// Enter command mode.
     pub fn enter_command_mode(&mut self) {
         self.mode = Mode::Command;
-        self.command_buffer.clear();
+        self.line_input = tui_input::Input::default();
         self.command_history.reset_navigation();
     }
 
     /// Return to normal mode.
     pub fn enter_normal_mode(&mut self) {
         self.mode = Mode::Normal;
-        self.command_buffer.clear();
+        self.line_input = tui_input::Input::default();
     }
 
     /// Enter search mode.
     pub fn enter_search_mode(&mut self) {
         self.mode = Mode::Search;
-        self.search.pattern.clear();
+        self.line_input = tui_input::Input::default();
     }
 
     /// Enter visual selection mode.
@@ -1291,8 +1284,8 @@ impl App {
 
     /// Execute a command from command mode.
     pub fn execute_command(&mut self) {
-        let command = self.command_buffer.trim().to_string();
-        self.command_buffer.clear();
+        let command = self.line_input.value().trim().to_string();
+        self.line_input = tui_input::Input::default();
         self.mode = Mode::Normal;
 
         if command.is_empty() {
@@ -1454,6 +1447,7 @@ impl App {
         match parts {
             ["?" | "help"] => {
                 self.show_help = true;
+                self.help_scroll = 0;
                 true
             }
             ["ruler"] => {
@@ -1518,6 +1512,7 @@ impl App {
             }
             ["info"] => {
                 self.show_info = !self.show_info;
+                self.info_scroll = 0;
                 true
             }
             ["gapcols"] | ["gapcol"] => {
@@ -1728,6 +1723,7 @@ impl App {
     /// Toggle help display.
     pub fn toggle_help(&mut self) {
         self.show_help = !self.show_help;
+        self.help_scroll = 0;
     }
 
     /// Enable horizontal split (top/bottom panes).
@@ -1951,26 +1947,30 @@ impl App {
 
     /// Navigate to previous command in history (Up arrow).
     pub fn command_history_prev(&mut self) {
-        if let Some(entry) = self.command_history.prev(&self.command_buffer) {
-            self.command_buffer = entry.to_string();
+        if let Some(entry) = self.command_history.prev(self.line_input.value()) {
+            self.line_input = tui_input::Input::new(entry.to_string());
         }
     }
 
     /// Navigate to next command in history (Down arrow).
     pub fn command_history_next(&mut self) {
         if let Some(entry) = self.command_history.next() {
-            self.command_buffer = entry.to_string();
+            self.line_input = tui_input::Input::new(entry.to_string());
         }
     }
 
     /// Navigate to previous search in history (Up arrow).
     pub fn search_history_prev(&mut self) {
-        self.search.history_prev();
+        if let Some(entry) = self.search.history.prev(self.line_input.value()) {
+            self.line_input = tui_input::Input::new(entry.to_string());
+        }
     }
 
     /// Navigate to next search in history (Down arrow).
     pub fn search_history_next(&mut self) {
-        self.search.history_next();
+        if let Some(entry) = self.search.history.next() {
+            self.line_input = tui_input::Input::new(entry.to_string());
+        }
     }
 
     /// Mark the alignment as modified.

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,6 +1,7 @@
 //! Vim-style input handling.
 
-use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use tui_input::backend::crossterm::EventHandler;
 
 use crate::app::{App, Mode};
 
@@ -22,6 +23,32 @@ fn handle_msa_picker(app: &mut App, key: KeyEvent) {
         }
         KeyCode::Esc | KeyCode::Char('q') => app.show_msa_picker = false,
         _ => {}
+    }
+}
+
+/// Handle keys while a scrollable overlay (help/info) is open.
+/// Scrolling keys adjust `scroll`; any other key closes the overlay.
+/// The scroll offset is clamped against content by the renderer, so here we
+/// only bump it up/down (saturating).
+fn handle_overlay_keys(key: KeyEvent, show: &mut bool, scroll: &mut u16) {
+    match (key.modifiers, key.code) {
+        (KeyModifiers::NONE, KeyCode::Char('j') | KeyCode::Down) => {
+            *scroll = scroll.saturating_add(1);
+        }
+        (KeyModifiers::NONE, KeyCode::Char('k') | KeyCode::Up) => {
+            *scroll = scroll.saturating_sub(1);
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('d')) => {
+            *scroll = scroll.saturating_add(10);
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
+            *scroll = scroll.saturating_sub(10);
+        }
+        // Esc/q/Enter (and anything else) close the overlay.
+        _ => {
+            *show = false;
+            *scroll = 0;
+        }
     }
 }
 
@@ -111,15 +138,15 @@ pub fn handle_key(app: &mut App, key: KeyEvent, page_size: usize) {
         return;
     }
 
-    // Close help overlay on any keypress
+    // Help overlay: scroll with j/k/arrows/Ctrl-d/u, close on Esc/q/Enter/other.
     if app.show_help {
-        app.show_help = false;
+        handle_overlay_keys(key, &mut app.show_help, &mut app.help_scroll);
         return;
     }
 
-    // Close info overlay on any keypress
+    // Info overlay: scroll with j/k/arrows/Ctrl-d/u, close on Esc/q/Enter/other.
     if app.show_info {
-        app.show_info = false;
+        handle_overlay_keys(key, &mut app.show_info, &mut app.info_scroll);
         return;
     }
 
@@ -387,10 +414,6 @@ fn handle_command_mode(app: &mut App, key: KeyEvent) {
             app.completion = None;
             app.execute_command();
         }
-        KeyCode::Backspace => {
-            app.completion = None;
-            app.command_buffer.pop();
-        }
         KeyCode::Up => {
             app.command_history_prev();
         }
@@ -400,11 +423,12 @@ fn handle_command_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Tab => {
             handle_tab_completion(app);
         }
-        KeyCode::Char(c) => {
+        // All other keys (chars, Backspace, cursor movement) go to the
+        // cursor-aware line editor.
+        _ => {
             app.completion = None;
-            app.command_buffer.push(c);
+            app.line_input.handle_event(&Event::Key(key));
         }
-        _ => {}
     }
 }
 
@@ -413,7 +437,7 @@ fn handle_tab_completion(app: &mut App) {
     use crate::app::CompletionState;
 
     // Check if we're completing a file path command
-    let buffer = app.command_buffer.clone();
+    let buffer = app.line_input.value().to_string();
     let (cmd, partial_path) = if let Some(rest) = buffer.strip_prefix("e ") {
         ("e ", rest)
     } else if let Some(rest) = buffer.strip_prefix("edit ") {
@@ -431,7 +455,7 @@ fn handle_tab_completion(app: &mut App) {
         && !state.candidates.is_empty()
     {
         state.index = (state.index + 1) % state.candidates.len();
-        app.command_buffer = format!("{}{}", cmd, state.candidates[state.index]);
+        app.line_input = tui_input::Input::new(format!("{}{}", cmd, state.candidates[state.index]));
         return;
     }
 
@@ -445,11 +469,11 @@ fn handle_tab_completion(app: &mut App) {
 
     if candidates.len() == 1 {
         // Single match - complete it
-        app.command_buffer = format!("{}{}", cmd, candidates[0]);
+        app.line_input = tui_input::Input::new(format!("{}{}", cmd, candidates[0]));
         app.completion = None;
     } else {
         // Multiple matches - start cycling
-        app.command_buffer = format!("{}{}", cmd, candidates[0]);
+        app.line_input = tui_input::Input::new(format!("{}{}", cmd, candidates[0]));
         app.completion = Some(CompletionState {
             candidates,
             index: 0,
@@ -533,14 +557,14 @@ fn handle_search_mode(app: &mut App, key: KeyEvent) {
             app.enter_normal_mode();
         }
         KeyCode::Enter => {
+            // Commit the live-edited value as the search pattern before searching.
+            app.search.pattern = app.line_input.value().to_string();
             app.execute_search();
             app.enter_normal_mode();
         }
-        KeyCode::Backspace => {
-            app.search.pattern.pop();
-            if app.search.pattern.is_empty() {
-                app.enter_normal_mode();
-            }
+        // Backspace on an empty line exits search mode (vim-like).
+        KeyCode::Backspace if app.line_input.value().is_empty() => {
+            app.enter_normal_mode();
         }
         KeyCode::Up => {
             app.search_history_prev();
@@ -548,10 +572,11 @@ fn handle_search_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Down => {
             app.search_history_next();
         }
-        KeyCode::Char(c) => {
-            app.search.pattern.push(c);
+        // All other keys (chars, Backspace, cursor movement) go to the
+        // cursor-aware line editor.
+        _ => {
+            app.line_input.handle_event(&Event::Key(key));
         }
-        _ => {}
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,7 +6,10 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{
+        Block, Borders, Clear, List, ListItem, ListState, Paragraph, Scrollbar,
+        ScrollbarOrientation, ScrollbarState,
+    },
 };
 
 use crate::app::{ActivePane, App, ColorScheme, Mode, SplitMode, TerminalTheme};
@@ -117,19 +120,13 @@ pub fn render(frame: &mut Frame, app: &App) {
 
 /// Render the MSA (multiple-alignment) selection overlay.
 fn render_msa_picker(frame: &mut Frame, app: &App) {
-    let mut lines = vec![
-        Line::from(Span::styled(
-            "Select alignment",
-            Style::default().add_modifier(Modifier::BOLD),
-        )),
-        Line::from(""),
-    ];
-
+    // Build one list item per alignment. The selection marker and highlight are
+    // provided by the List widget (highlight_symbol / highlight_style), so items
+    // themselves only carry the (current) distinction.
+    let mut items: Vec<ListItem> = Vec::with_capacity(app.alignments.len());
+    let mut content_width: u16 = 0;
     for (i, alignment) in app.alignments.iter().enumerate() {
-        let selected = i == app.msa_picker_selection;
         let current = i == app.current_alignment;
-
-        let marker = if selected { "▶ " } else { "  " };
         let label = app.alignment_label(i);
         let detail = format!(
             "{}x{}{}",
@@ -137,32 +134,31 @@ fn render_msa_picker(frame: &mut Frame, app: &App) {
             alignment.width(),
             if current { " (current)" } else { "" }
         );
-        let text = format!("{marker}{:>2}. {label}  [{detail}]", i + 1);
+        let text = format!("{:>2}. {label}  [{detail}]", i + 1);
 
-        let style = if selected {
+        let style = if current {
             Style::default()
-                .fg(Color::Black)
-                .bg(Color::Cyan)
+                .fg(Color::White)
                 .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(Color::White)
         };
-        lines.push(Line::from(Span::styled(text, style)));
+        content_width = content_width.max(Line::from(text.as_str()).width() as u16);
+        items.push(ListItem::new(Line::from(Span::styled(text, style))));
     }
 
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        "j/k move · Enter select · Esc cancel",
-        Style::default().fg(Color::DarkGray),
-    )));
+    let hint = "j/k move · Enter select · Esc cancel";
+    content_width = content_width.max(hint.len() as u16);
 
-    // Calculate centered popup area
+    // Calculate centered popup area. Add room for borders, the highlight symbol
+    // ("▶ ", 2 cells), and the footer hint line.
     let area = frame.area();
-    let content_width = lines.iter().map(|l| l.width()).max().unwrap_or(20) as u16;
-    let popup_width = (content_width + 4)
+    let popup_width = (content_width + 6)
         .min(area.width.saturating_sub(4))
         .max(24);
-    let popup_height = (lines.len() as u16 + 2).min(area.height.saturating_sub(2));
+    // Content height: list rows + blank + hint, capped by the terminal.
+    let content_height = app.alignments.len() as u16 + 2;
+    let popup_height = (content_height + 2).min(area.height.saturating_sub(2));
     let popup_x = (area.width.saturating_sub(popup_width)) / 2;
     let popup_y = (area.height.saturating_sub(popup_height)) / 2;
     let popup_area = Rect::new(popup_x, popup_y, popup_width, popup_height);
@@ -175,11 +171,35 @@ fn render_msa_picker(frame: &mut Frame, app: &App) {
         .border_style(Style::default().fg(Color::Cyan))
         .style(Style::default().bg(Color::Black));
 
-    let paragraph = Paragraph::new(lines)
-        .block(block)
-        .style(Style::default().bg(Color::Black));
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
 
-    frame.render_widget(paragraph, popup_area);
+    // Split inner area into the scrollable list and a footer hint line.
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    let list = List::new(items)
+        .style(Style::default().bg(Color::Black).fg(Color::White))
+        .highlight_style(
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+
+    // Rebuild the ListState from the source-of-truth index each render.
+    let mut list_state = ListState::default().with_selected(Some(app.msa_picker_selection));
+    frame.render_stateful_widget(list, chunks[0], &mut list_state);
+
+    let hint_para = Paragraph::new(Line::from(Span::styled(
+        hint,
+        Style::default().fg(Color::DarkGray),
+    )))
+    .style(Style::default().bg(Color::Black));
+    frame.render_widget(hint_para, chunks[1]);
 }
 
 /// Height of the ruler in lines.
@@ -501,6 +521,31 @@ fn render_alignment_pane(
             ruler_height,
             annotation_height,
             actual_seq_rows,
+        );
+    }
+
+    // === Render scrollbars over the pane's borders ===
+    // Vertical scrollbar (right border) when more sequences than fit.
+    if visible_seq_count > visible_rows {
+        let mut vscroll_state = ScrollbarState::new(visible_seq_count).position(viewport_row);
+        frame.render_stateful_widget(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(None)
+                .end_symbol(None),
+            area,
+            &mut vscroll_state,
+        );
+    }
+
+    // Horizontal scrollbar (bottom border) when the alignment is wider than fits.
+    if alignment_width > seq_width {
+        let mut hscroll_state = ScrollbarState::new(alignment_width).position(viewport_col);
+        frame.render_stateful_widget(
+            Scrollbar::new(ScrollbarOrientation::HorizontalBottom)
+                .begin_symbol(None)
+                .end_symbol(None),
+            area,
+            &mut hscroll_state,
         );
     }
 }
@@ -1450,22 +1495,23 @@ fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
 
 /// Render the command/message line.
 fn render_command_line(frame: &mut Frame, app: &App, area: Rect) {
+    // Prefix is a single cell (":" or "/") for both command and search modes.
+    let prefix_width: u16 = 1;
+
     let content = match app.mode {
         Mode::Command => Line::from(vec![
             Span::styled(
                 ":",
                 Style::default().fg(app.theme.command_line.command_prefix.to_color()),
             ),
-            Span::raw(&app.command_buffer),
-            Span::styled("_", Style::default().add_modifier(Modifier::SLOW_BLINK)),
+            Span::raw(app.line_input.value()),
         ]),
         Mode::Search => Line::from(vec![
             Span::styled(
                 "/",
                 Style::default().fg(app.theme.command_line.search_prefix.to_color()),
             ),
-            Span::raw(&app.search.pattern),
-            Span::styled("_", Style::default().add_modifier(Modifier::SLOW_BLINK)),
+            Span::raw(app.line_input.value()),
         ]),
         _ => {
             if let Some(msg) = &app.status_message {
@@ -1482,6 +1528,14 @@ fn render_command_line(frame: &mut Frame, app: &App, area: Rect) {
 
     let paragraph = Paragraph::new(content);
     frame.render_widget(paragraph, area);
+
+    // Place a real terminal cursor after the prefix in command/search modes.
+    if matches!(app.mode, Mode::Command | Mode::Search) {
+        frame.set_cursor_position((
+            area.x + prefix_width + app.line_input.visual_cursor() as u16,
+            area.y,
+        ));
+    }
 }
 
 /// Calculate visible dimensions for the alignment area.
@@ -1736,12 +1790,13 @@ fn render_help(frame: &mut Frame, app: &App) {
         Line::from("  :help       Show this help"),
         Line::from(""),
         Line::from(Span::styled(
-            "Press any key to close",
+            "j/k scroll · any other key to close",
             Style::default().fg(Color::DarkGray),
         )),
     ];
 
-    // Calculate centered popup area
+    // Calculate centered popup area (cap height at the terminal so tall content
+    // scrolls rather than being clipped off-screen).
     let area = frame.area();
     let popup_width = 50.min(area.width.saturating_sub(4));
     let popup_height = (help_text.len() as u16 + 2).min(area.height.saturating_sub(4));
@@ -1760,8 +1815,14 @@ fn render_help(frame: &mut Frame, app: &App) {
         .border_style(Style::default().fg(popup_border))
         .style(Style::default().bg(popup_bg));
 
+    // Clamp the scroll so the last line stays visible (can't scroll past content).
+    let inner_height = popup_area.height.saturating_sub(2);
+    let max_scroll = (help_text.len() as u16).saturating_sub(inner_height);
+    let scroll = app.help_scroll.min(max_scroll);
+
     let help_paragraph = Paragraph::new(help_text)
         .block(help_block)
+        .scroll((scroll, 0))
         .style(Style::default().bg(popup_bg));
 
     frame.render_widget(help_paragraph, popup_area);
@@ -1835,7 +1896,7 @@ fn render_info(frame: &mut Frame, app: &App) {
 
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
-        "Press any key to close",
+        "j/k scroll · any other key to close",
         Style::default().fg(Color::DarkGray),
     )));
 
@@ -1858,8 +1919,14 @@ fn render_info(frame: &mut Frame, app: &App) {
         .border_style(Style::default().fg(popup_border))
         .style(Style::default().bg(popup_bg));
 
+    // Clamp the scroll so the last line stays visible (can't scroll past content).
+    let inner_height = popup_area.height.saturating_sub(2);
+    let max_scroll = (lines.len() as u16).saturating_sub(inner_height);
+    let scroll = app.info_scroll.min(max_scroll);
+
     let info_paragraph = Paragraph::new(lines)
         .block(info_block)
+        .scroll((scroll, 0))
         .style(Style::default().bg(popup_bg));
 
     frame.render_widget(info_paragraph, popup_area);


### PR DESCRIPTION
## Summary

Replaces four hand-rolled TUI pieces with ratatui built-ins and one small crate, fixing two latent UX bugs along the way. Two of the four changes need **no new dependency** (widgets ship in ratatui 0.30).

| Area | Before | After |
|---|---|---|
| **Scrollbars** | none — viewport position invisible | vertical + horizontal `Scrollbar` on each alignment pane, tracking the viewport (works in splits) |
| **MSA picker** | hand-built `Vec<Line>` that clamped its own height → entries overflowed with no way to reach them | `List`/`ListState` that scrolls to the selection automatically |
| **`:` / `/` input** | append-only `String` with a fake blinking `_`; no cursor movement | `tui-input`: Left/Right/Home/End, mid-line edit, word-delete, and a real terminal cursor |
| **Help / info overlays** | height clamped → bottom keybindings truncated on short terminals | scroll offset (`j`/`k`, `Ctrl-d`/`Ctrl-u`) so all content is reachable |

## Dependency

Adds `tui-input` 0.15 (`ratatui-crossterm` feature). Scrollbars and the List picker use built-in ratatui 0.30 widgets only.

## Implementation notes

- Command and search share one `tui_input::Input` (never active simultaneously). On Enter, search copies `line_input.value()` into `search.pattern`, so existing match-highlighting/history logic is untouched.
- History recall and Tab path-completion rebuild the `Input`. "Backspace on empty search exits search mode" behavior preserved.
- Overlay scroll is clamped in the render functions (where content length + inner height are known); input handlers only bump the offset saturating.
- Dead `SearchState::history_prev/next` removed; search-history nav reimplemented against `line_input`.

## Verification

- `cargo build` — clean, no warnings
- `cargo clippy --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --all-features` — **52 passed, 0 failed**
- Binary launches, `--version`/`--help` OK

⚠️ **Interactive visual behavior (scrollbars rendering, in-line cursor, overlay scrolling) was not driven end-to-end** — that requires a real terminal. Suggested manual smoke test:
1. Open a large alignment, scroll down/right → confirm both scrollbars track the viewport; repeat after `:split` / `:vsplit`.
2. `:`/`/` → type, move with ←/→/Home/End, edit mid-string, confirm a real cursor; Up/Down recall history; Tab completes paths on `:e `.
3. Open a multi-alignment file (`examples/multi_msa.stk`) or `:msa`, shrink the terminal so the list overflows → confirm it scrolls to the selection.
4. Shrink vertically, press `?` → confirm help scrolls with `j`/`k` instead of truncating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)