### PR TITLE
Fast, non-blocking clustering with a correct dendrogram

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ dirs = "6"
 thiserror = "2"
 unicode-width = "0.2"
 kodama = "0.3"
+rayon = "1.10"
 termbg = "0.6"
 flate2 = "1.1"
 strum = { version = "0.27", features = ["derive"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,9 @@ use crate::history::InputHistory;
 use crate::stockholm::{Alignment, SequenceType};
 use crate::structure::StructureCache;
 
+/// Braille spinner frames used while a background clustering job runs.
+const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
 /// Search state for pattern matching in sequences.
 #[derive(Debug, Clone, Default)]
 pub struct SearchState {
@@ -145,6 +148,19 @@ pub enum TerminalTheme {
     Dark,
 }
 
+/// A clustering computation running on a background thread.
+///
+/// `:cluster` on large alignments can take seconds; running it off the UI thread
+/// keeps the TUI responsive while a spinner animates.
+pub struct ClusteringJob {
+    /// Receiver for the finished [`crate::clustering::ClusterResult`].
+    pub rx: std::sync::mpsc::Receiver<crate::clustering::ClusterResult>,
+    /// Number of sequences being clustered (for the status message).
+    pub seq_count: usize,
+    /// Current spinner frame index.
+    pub spinner: usize,
+}
+
 /// Application state.
 pub struct App {
     // === Public - Core data ===
@@ -250,6 +266,8 @@ pub struct App {
     pub(crate) show_tree: bool,
     /// Group order when clustering with collapse (maps display_row -> group_index).
     pub(crate) cluster_group_order: Option<Vec<usize>>,
+    /// In-progress background clustering job, if any.
+    pub(crate) clustering_job: Option<ClusteringJob>,
     /// Terminal color theme (detected at startup).
     pub terminal_theme: TerminalTheme,
     /// UI theme colors.
@@ -351,6 +369,7 @@ impl Default for App {
             tree_width: 0,
             show_tree: false,
             cluster_group_order: None,
+            clustering_job: None,
             terminal_theme: TerminalTheme::Dark,
             theme: Theme::default(),
             collapse_identical: false,
@@ -1015,6 +1034,10 @@ impl App {
     /// For block pastes, replaces characters in place.
     /// For line-wise pastes, appends sequences after the cursor row.
     pub fn paste(&mut self) {
+        if self.is_clustering() {
+            self.set_status("Clustering in progress…");
+            return;
+        }
         if self.clipboard.is_none() {
             self.set_status("Nothing to paste");
             return;
@@ -1673,15 +1696,17 @@ impl App {
             return matches!(parts, ["cluster"] | ["uncluster"] | ["tree"] | ["collapse"]);
         }
 
+        // Block re-invocation of clustering-mutating commands while a job runs.
+        if self.is_clustering() && matches!(parts, ["cluster"] | ["uncluster"] | ["collapse"]) {
+            self.set_status("Clustering in progress…");
+            return true;
+        }
+
         match parts {
             ["cluster"] => {
-                self.cluster_sequences();
-                // Auto-show tree so user can see sequences were reordered
-                self.show_tree = true;
-                self.set_status(format!(
-                    "Clustered {} sequences by similarity (tree visible)",
-                    self.alignment.num_sequences()
-                ));
+                // Run clustering on a background thread; poll_clustering sets the
+                // final status and applies auto-hide once the result is ready.
+                self.start_clustering();
                 true
             }
             ["uncluster"] => {
@@ -2078,28 +2103,24 @@ impl App {
         }
     }
 
-    /// Cluster sequences by similarity using hierarchical clustering.
-    /// Uses precomputed collapse groups to avoid redundant distance calculations.
-    pub fn cluster_sequences(&mut self) {
-        if self.alignment.sequences.is_empty() {
-            return;
-        }
-
-        // Get sequence chars for clustering
-        let seq_chars: Vec<Vec<char>> = self
-            .alignment
+    /// Snapshot the alignment sequences as owned bytes for clustering.
+    /// Alignments are ASCII, so a byte representation is exact and `Send`.
+    fn snapshot_seq_bytes(&self) -> Vec<Vec<u8>> {
+        self.alignment
             .sequences
             .iter()
-            .map(|s| s.chars().to_vec())
-            .collect();
+            .map(|s| s.data().into_bytes())
+            .collect()
+    }
 
-        // Compute cluster order and tree using UPGMA
-        // Use collapse groups to cluster only unique sequences (optimization)
-        let result = crate::clustering::cluster_sequences_with_collapse(
-            &seq_chars,
-            &self.gap_chars,
-            &self.collapse_groups,
-        );
+    /// Returns true when a background clustering job is in progress.
+    pub fn is_clustering(&self) -> bool {
+        self.clustering_job.is_some()
+    }
+
+    /// Apply a finished [`crate::clustering::ClusterResult`] to app state and clamp
+    /// the cursor. Shared by the synchronous and background clustering paths.
+    fn apply_cluster_result(&mut self, result: crate::clustering::ClusterResult) {
         self.cluster_order = Some(result.order);
         self.cluster_tree = Some(result.tree_lines);
         self.collapsed_tree = result.collapsed_tree_lines;
@@ -2109,6 +2130,101 @@ impl App {
         // Clamp cursor to valid range
         if self.cursor_row >= self.visible_sequence_count() {
             self.cursor_row = self.visible_sequence_count().saturating_sub(1);
+        }
+    }
+
+    /// Cluster sequences by similarity using hierarchical clustering, synchronously.
+    /// Uses precomputed collapse groups to avoid redundant distance calculations.
+    ///
+    /// This blocks the caller; used for CLI startup and post-paste re-clustering
+    /// where blocking is acceptable. Interactive `:cluster` uses [`Self::start_clustering`].
+    pub fn cluster_sequences(&mut self) {
+        self.cluster_now();
+    }
+
+    /// Run the clustering computation synchronously and apply the result.
+    fn cluster_now(&mut self) {
+        if self.alignment.sequences.is_empty() {
+            return;
+        }
+
+        let seq_bytes = self.snapshot_seq_bytes();
+        let gap_lut = crate::clustering::build_gap_lut(&self.gap_chars);
+
+        let result = crate::clustering::cluster_sequences_with_collapse(
+            &seq_bytes,
+            &gap_lut,
+            &self.collapse_groups,
+        );
+        self.apply_cluster_result(result);
+    }
+
+    /// Start clustering on a background thread, animating a spinner while it runs.
+    ///
+    /// Snapshots owned, `Send` data (byte sequences, gap LUT, collapse groups) and
+    /// spawns a thread that computes the result and sends it over an mpsc channel.
+    pub fn start_clustering(&mut self) {
+        if self.alignment.sequences.is_empty() {
+            return;
+        }
+
+        let seq_bytes = self.snapshot_seq_bytes();
+        let gap_lut = crate::clustering::build_gap_lut(&self.gap_chars);
+        let collapse_groups = self.collapse_groups.clone();
+        let seq_count = self.alignment.num_sequences();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = crate::clustering::cluster_sequences_with_collapse(
+                &seq_bytes,
+                &gap_lut,
+                &collapse_groups,
+            );
+            // Ignore send errors: the receiver may have been dropped.
+            let _ = tx.send(result);
+        });
+
+        self.clustering_job = Some(ClusteringJob {
+            rx,
+            seq_count,
+            spinner: 0,
+        });
+        self.set_status(format!(
+            "{} Clustering {seq_count} sequences…",
+            SPINNER_FRAMES[0]
+        ));
+    }
+
+    /// Poll the background clustering job (call once per event-loop iteration).
+    /// Applies the result when ready and animates the spinner while it runs.
+    pub fn poll_clustering(&mut self) {
+        let Some(job) = self.clustering_job.as_mut() else {
+            return;
+        };
+
+        match job.rx.try_recv() {
+            Ok(result) => {
+                let seq_count = job.seq_count;
+                self.clustering_job = None;
+                self.apply_cluster_result(result);
+
+                // Show the tree by default; it scrolls line-for-line with the
+                // sequences, so it's no denser per screen at large N. :tree toggles it.
+                self.show_tree = true;
+                self.set_status(format!(
+                    "Clustered {seq_count} sequences by similarity (tree visible)"
+                ));
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                job.spinner = (job.spinner + 1) % SPINNER_FRAMES.len();
+                let frame = SPINNER_FRAMES[job.spinner];
+                let seq_count = job.seq_count;
+                self.set_status(format!("{frame} Clustering {seq_count} sequences…"));
+            }
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                self.clustering_job = None;
+                self.set_status("Clustering failed (worker thread stopped)");
+            }
         }
     }
 

--- a/src/clustering.rs
+++ b/src/clustering.rs
@@ -4,6 +4,7 @@
 //! Identical sequences are collapsed before clustering to reduce O(n²) distance computation.
 
 use kodama::{Method, linkage};
+use rayon::prelude::*;
 
 /// Result of clustering: leaf order and optional tree visualization.
 #[derive(Debug, Clone)]
@@ -22,37 +23,60 @@ pub struct ClusterResult {
     pub collapsed_tree_lines: Option<Vec<String>>,
 }
 
-/// Compute Hamming distance between two sequences (count mismatches).
-/// Gaps vs gaps count as match, gaps vs residue count as mismatch.
-pub fn hamming_distance(seq1: &[char], seq2: &[char], gap_chars: &[char]) -> usize {
+/// Build a 256-entry lookup table marking which ASCII bytes are gap characters.
+/// Alignments are ASCII, so a byte LUT gives O(1) gap tests.
+pub fn build_gap_lut(gap_chars: &[char]) -> [bool; 256] {
+    let mut lut = [false; 256];
+    for &c in gap_chars {
+        if c.is_ascii() {
+            lut[c as usize] = true;
+        }
+    }
+    lut
+}
+
+/// Compute Hamming distance between two byte sequences (count mismatches).
+/// Comparison is case-insensitive. Both gaps count as a match; one gap and one
+/// residue counts as a mismatch; two differing residues count as a mismatch.
+pub fn hamming_distance(seq1: &[u8], seq2: &[u8], gap_lut: &[bool; 256]) -> usize {
     seq1.iter()
         .zip(seq2.iter())
-        .filter(|(a, b)| {
-            let a_gap = gap_chars.contains(a);
-            let b_gap = gap_chars.contains(b);
+        .filter(|&(&a, &b)| {
+            let a_gap = gap_lut[a as usize];
+            let b_gap = gap_lut[b as usize];
             if a_gap && b_gap {
                 // Both gaps = match (don't count as mismatch)
                 false
             } else {
                 // One gap + one residue = mismatch
-                // Two different residues = mismatch
-                !a.eq_ignore_ascii_case(b)
+                // Two different residues = mismatch (case-insensitive)
+                !a.eq_ignore_ascii_case(&b)
             }
         })
         .count()
 }
 
 /// Compute condensed distance matrix for all sequence pairs.
-/// Returns distances in row-major condensed form for kodama.
-pub fn compute_distance_matrix(sequences: &[Vec<char>], gap_chars: &[char]) -> Vec<f64> {
+/// Returns distances in row-major condensed form for kodama:
+/// for i in 0..n, for j in i+1..n. Parallelized across rows with rayon while
+/// preserving that exact ordering.
+pub fn compute_distance_matrix(sequences: &[Vec<u8>], gap_lut: &[bool; 256]) -> Vec<f64> {
     let n = sequences.len();
-    let mut distances = Vec::with_capacity(n * (n - 1) / 2);
 
-    for i in 0..n {
-        for j in (i + 1)..n {
-            let dist = hamming_distance(&sequences[i], &sequences[j], gap_chars);
-            distances.push(dist as f64);
-        }
+    // Each row i contributes distances to j = i+1..n, in order.
+    let rows: Vec<Vec<f64>> = (0..n)
+        .into_par_iter()
+        .map(|i| {
+            (i + 1..n)
+                .map(|j| hamming_distance(&sequences[i], &sequences[j], gap_lut) as f64)
+                .collect::<Vec<f64>>()
+        })
+        .collect();
+
+    // Flatten in row order to reproduce the original nested-loop layout exactly.
+    let mut distances = Vec::with_capacity(n * (n - 1) / 2);
+    for row in rows {
+        distances.extend(row);
     }
     distances
 }
@@ -60,12 +84,12 @@ pub fn compute_distance_matrix(sequences: &[Vec<char>], gap_chars: &[char]) -> V
 /// Perform hierarchical clustering and return sequence indices in dendrogram order.
 /// Uses UPGMA (average linkage) for balanced trees.
 #[allow(dead_code)]
-pub fn cluster_sequences(sequences: &[Vec<char>], gap_chars: &[char]) -> Vec<usize> {
-    cluster_sequences_with_tree(sequences, gap_chars).order
+pub fn cluster_sequences(sequences: &[Vec<u8>], gap_lut: &[bool; 256]) -> Vec<usize> {
+    cluster_sequences_with_tree(sequences, gap_lut).order
 }
 
 /// Perform hierarchical clustering and return both order and tree visualization.
-pub fn cluster_sequences_with_tree(sequences: &[Vec<char>], gap_chars: &[char]) -> ClusterResult {
+pub fn cluster_sequences_with_tree(sequences: &[Vec<u8>], gap_lut: &[bool; 256]) -> ClusterResult {
     let n = sequences.len();
     if n <= 1 {
         return ClusterResult {
@@ -81,7 +105,7 @@ pub fn cluster_sequences_with_tree(sequences: &[Vec<char>], gap_chars: &[char]) 
         };
     }
 
-    let mut distances = compute_distance_matrix(sequences, gap_chars);
+    let mut distances = compute_distance_matrix(sequences, gap_lut);
     let dendrogram = linkage(&mut distances, n, Method::Average);
 
     // Extract leaf order from dendrogram (depth-first traversal)
@@ -103,8 +127,8 @@ pub fn cluster_sequences_with_tree(sequences: &[Vec<char>], gap_chars: &[char]) 
 /// This clusters only representative sequences, then expands the result.
 /// Much faster when there are many identical sequences.
 pub fn cluster_sequences_with_collapse(
-    sequences: &[Vec<char>],
-    gap_chars: &[char],
+    sequences: &[Vec<u8>],
+    gap_lut: &[bool; 256],
     collapse_groups: &[(usize, Vec<usize>)],
 ) -> ClusterResult {
     let n = sequences.len();
@@ -113,7 +137,7 @@ pub fn cluster_sequences_with_collapse(
     // If no duplicates or trivial case, use standard clustering
     // but still produce group_order so collapse+cluster works correctly
     if num_unique == n || n <= 1 {
-        let mut result = cluster_sequences_with_tree(sequences, gap_chars);
+        let mut result = cluster_sequences_with_tree(sequences, gap_lut);
         // Map each sequence index back to its group index
         // When all sequences are unique, group i contains sequence collapse_groups[i].0
         // So we need: for each position in order, find which group that sequence belongs to
@@ -128,6 +152,7 @@ pub fn cluster_sequences_with_collapse(
                 .map(|&seq_idx| seq_to_group[seq_idx])
                 .collect(),
         );
+        // collapsed_tree mirrors the (possibly empty) per-row tree.
         result.collapsed_tree_lines = Some(result.tree_lines.clone());
         return result;
     }
@@ -145,31 +170,33 @@ pub fn cluster_sequences_with_collapse(
 
     // Extract representative sequences
     let rep_indices: Vec<usize> = collapse_groups.iter().map(|(rep, _)| *rep).collect();
-    let rep_sequences: Vec<Vec<char>> = rep_indices
+    let rep_sequences: Vec<Vec<u8>> = rep_indices
         .iter()
         .map(|&idx| sequences[idx].clone())
         .collect();
 
     // Cluster only the representatives
-    let mut distances = compute_distance_matrix(&rep_sequences, gap_chars);
+    let mut distances = compute_distance_matrix(&rep_sequences, gap_lut);
     let dendrogram = linkage(&mut distances, num_unique, Method::Average);
 
     // Get order of representatives
     let rep_order = dendrogram_order(&dendrogram, num_unique);
 
-    // Build tree for representatives
+    // Build tree for representatives (one line per group / representative).
     let (rep_tree_lines, tree_width) = build_tree_chars(&dendrogram, num_unique, &rep_order);
 
-    // Expand order: for each representative in order, include all its members
+    // Expand order: for each representative in order, include all its members.
     let mut order = Vec::with_capacity(n);
     let mut tree_lines = Vec::with_capacity(n);
 
     // Build collapsed tree lines in display order (one per group)
     let mut collapsed_tree_lines = Vec::with_capacity(num_unique);
 
-    for &rep_idx in &rep_order {
+    for (display_pos, &rep_idx) in rep_order.iter().enumerate() {
         let (_, members) = &collapse_groups[rep_idx];
-        let tree_line = &rep_tree_lines[rep_order.iter().position(|&x| x == rep_idx).unwrap()];
+
+        // rep_tree_lines is indexed by display position (row) already.
+        let tree_line = rep_tree_lines.get(display_pos).cloned().unwrap_or_default();
 
         // Add to collapsed tree (one line per group)
         collapsed_tree_lines.push(tree_line.clone());
@@ -225,9 +252,82 @@ fn traverse_cluster(cluster: usize, n: usize, steps: &[kodama::Step<f64>], order
     }
 }
 
-/// Build dendrogram representation showing tree topology.
-/// Uses bracket-style characters: ─┬┘│ to show which sequences group together.
-/// Returns (tree_lines, tree_width).
+/// Merge a newly-drawn box-drawing direction into an existing grid cell so that
+/// segments meeting at a cell pick a visually-correct junction character.
+///
+/// `up`/`down`/`left`/`right` describe the connections the new segment adds. The
+/// existing cell's own connections are decoded, unioned with the new ones, and the
+/// matching box-drawing glyph is returned.
+fn merge_cell(existing: char, up: bool, down: bool, left: bool, right: bool) -> char {
+    // Decode existing connections. Half-line glyphs must round-trip so that a
+    // single-direction stub (e.g. the top of a vertical, which connects only
+    // downward) is not mistaken for a full line when another segment joins it.
+    let (mut eu, mut ed, mut el, mut er) = match existing {
+        '╵' => (true, false, false, false),
+        '╷' => (false, true, false, false),
+        '╴' => (false, false, true, false),
+        '╶' => (false, false, false, true),
+        '─' => (false, false, true, true),
+        '│' => (true, true, false, false),
+        '┌' => (false, true, false, true),
+        '┐' => (false, true, true, false),
+        '└' => (true, false, false, true),
+        '┘' => (true, false, true, false),
+        '├' => (true, true, false, true),
+        '┤' => (true, true, true, false),
+        '┬' => (false, true, true, true),
+        '┴' => (true, false, true, true),
+        '┼' => (true, true, true, true),
+        _ => (false, false, false, false),
+    };
+    eu |= up;
+    ed |= down;
+    el |= left;
+    er |= right;
+
+    match (eu, ed, el, er) {
+        (false, false, false, false) => ' ',
+        // Single directions (half lines) — kept distinct so corners can form.
+        (true, false, false, false) => '╵',
+        (false, true, false, false) => '╷',
+        (false, false, true, false) => '╴',
+        (false, false, false, true) => '╶',
+        // Straight lines.
+        (false, false, true, true) => '─',
+        (true, true, false, false) => '│',
+        // Corners.
+        (false, true, false, true) => '┌',
+        (false, true, true, false) => '┐',
+        (true, false, false, true) => '└',
+        (true, false, true, false) => '┘',
+        // Tees and cross.
+        (true, true, false, true) => '├',
+        (true, true, true, false) => '┤',
+        (false, true, true, true) => '┬',
+        (true, false, true, true) => '┴',
+        (true, true, true, true) => '┼',
+    }
+}
+
+/// Merge a direction set into a grid cell.
+fn draw(
+    grid: &mut [Vec<char>],
+    row: usize,
+    col: usize,
+    up: bool,
+    down: bool,
+    left: bool,
+    right: bool,
+) {
+    let cur = grid[row][col];
+    grid[row][col] = merge_cell(cur, up, down, left, right);
+}
+
+/// Build a rotated (left-to-right) dendrogram, scipy style.
+///
+/// Columns encode merge height (dissimilarity): leaves sit at column 0 on the left,
+/// the root merge sits at the far right. Rows are the display order. Returns
+/// (tree_lines, tree_width).
 fn build_tree_chars(
     dend: &kodama::Dendrogram<f64>,
     n: usize,
@@ -235,165 +335,261 @@ fn build_tree_chars(
 ) -> (Vec<String>, usize) {
     let steps = dend.steps();
 
-    const MAX_TREE_WIDTH: usize = 16;
-
     if steps.is_empty() || n <= 1 {
         return (vec!["─".to_string(); n], 1);
     }
 
-    // Map from original sequence index to display row
+    // Map from original sequence index to display row.
     let mut orig_to_row = vec![0usize; n];
     for (row, &orig) in order.iter().enumerate() {
         orig_to_row[orig] = row;
     }
 
-    // For each node (leaf or internal), track its row span in display order
-    // Leaves span a single row, internal nodes span from min to max of children
-    let mut node_row_min = vec![0usize; 2 * n - 1];
-    let mut node_row_max = vec![0usize; 2 * n - 1];
+    // Choose an adaptive tree width, capped so wide dendrograms stay readable.
+    let tree_width = 32.min((n - 1).max(1));
 
-    // Initialize leaves
+    let num_nodes = 2 * n - 1;
+    let mut conn_row = vec![0usize; num_nodes];
+    let mut node_col = vec![0usize; num_nodes];
+
+    // Leaves: connection row is their display row, column 0.
     for orig in 0..n {
-        let row = orig_to_row[orig];
-        node_row_min[orig] = row;
-        node_row_max[orig] = row;
+        conn_row[orig] = orig_to_row[orig];
+        node_col[orig] = 0;
     }
 
-    // Compute internal node spans (steps create nodes n, n+1, n+2, ...)
+    // Max dissimilarity is at the last (root) step since merges are monotonic.
+    let max_diss = steps.last().map(|s| s.dissimilarity).unwrap_or(0.0);
+
+    // Internal nodes: connection row is the (rounded) midpoint of children's rows;
+    // column scales with dissimilarity so higher merges sit further right.
+    let mut parent = vec![usize::MAX; num_nodes];
     for (i, step) in steps.iter().enumerate() {
         let node_id = n + i;
-        node_row_min[node_id] = node_row_min[step.cluster1].min(node_row_min[step.cluster2]);
-        node_row_max[node_id] = node_row_max[step.cluster1].max(node_row_max[step.cluster2]);
+        let c1 = step.cluster1;
+        let c2 = step.cluster2;
+        parent[c1] = node_id;
+        parent[c2] = node_id;
+        conn_row[node_id] = (conn_row[c1] + conn_row[c2]).div_ceil(2);
+        let col = if max_diss > 0.0 {
+            ((step.dissimilarity / max_diss) * (tree_width - 1) as f64).round() as usize
+        } else {
+            tree_width - 1
+        };
+        node_col[node_id] = col.min(tree_width - 1);
     }
 
-    // Assign columns to internal nodes using recursive traversal
-    // Each node gets the next available column when we "close" it
-    let mut node_col = vec![0usize; 2 * n - 1];
-    let mut next_col = 0usize;
-
-    // Process nodes in order of their creation (merge order)
-    // This ensures parent nodes get columns after their children
-    for (i, _step) in steps.iter().enumerate() {
-        let node_id = n + i;
-        node_col[node_id] = next_col;
-        next_col += 1;
-    }
-
-    let tree_width = next_col.clamp(1, MAX_TREE_WIDTH);
-
-    // Scale columns if we exceed max width
-    if next_col > MAX_TREE_WIDTH {
-        for col in node_col.iter_mut().skip(n) {
-            *col = (*col * (MAX_TREE_WIDTH - 1)) / (next_col - 1).max(1);
+    // A leaf pair ("cherry") spans two adjacent rows, so its join can only sit on
+    // one of them — no cell exists between. Point it toward its parent (top if the
+    // parent is above, bottom otherwise) so the outgoing branch reads as a straight
+    // line instead of always dog-legging from the bottom. Cherries never nest, and
+    // their span is fixed (both children are leaves), so this can't strand a branch.
+    for (i, step) in steps.iter().enumerate() {
+        let (c1, c2) = (step.cluster1, step.cluster2);
+        if c1 < n && c2 < n {
+            let node_id = n + i;
+            let top = conn_row[c1].min(conn_row[c2]);
+            let bottom = conn_row[c1].max(conn_row[c2]);
+            let p = parent[node_id];
+            conn_row[node_id] = if p != usize::MAX && conn_row[p] <= top {
+                top
+            } else {
+                bottom
+            };
         }
     }
 
-    // Build tree lines
-    let mut tree_lines = Vec::with_capacity(n);
+    // Grid of box-drawing characters.
+    let mut grid = vec![vec![' '; tree_width]; n];
 
-    for row in 0..n {
-        let mut chars = vec![' '; tree_width];
+    for (i, step) in steps.iter().enumerate() {
+        let node_id = n + i;
+        let col = node_col[node_id];
+        let c1 = step.cluster1;
+        let c2 = step.cluster2;
+        let r1 = conn_row[c1];
+        let r2 = conn_row[c2];
+        let (top, bottom) = if r1 <= r2 { (r1, r2) } else { (r2, r1) };
 
-        // For each internal node, draw its contribution to this row
-        for (i, _step) in steps.iter().enumerate() {
-            let node_id = n + i;
-            let col = node_col[node_id];
-            if col >= tree_width {
-                continue;
-            }
+        // Vertical segment at this node's column spanning its two children rows.
+        for r in top..=bottom {
+            let up = r > top;
+            let down = r < bottom;
+            draw(&mut grid, r, col, up, down, false, false);
+        }
 
-            let row_min = node_row_min[node_id];
-            let row_max = node_row_max[node_id];
-
-            if row < row_min || row > row_max {
-                // Outside this node's span
-                continue;
-            }
-
-            if row == row_min {
-                // Top of bracket
-                chars[col] = '┬';
-            } else if row == row_max {
-                // Bottom of bracket
-                chars[col] = '┘';
-            } else {
-                // Middle - vertical line (don't overwrite existing)
-                if chars[col] == ' ' {
-                    chars[col] = '│';
+        // Horizontal run at each child's connection row from the child's column to
+        // this node's column. A child's column is always <= this node's (merges are
+        // monotonic in height). When strictly less, draw the connector; on a tie the
+        // child already sits on this column's vertical spine, so drawing anything
+        // (a leftward stub) would dead-end into empty space.
+        for &(child, child_row) in &[(c1, r1), (c2, r2)] {
+            let child_col = node_col[child];
+            if child_col < col {
+                for cc in child_col..=col {
+                    let left = cc > child_col;
+                    let right = cc < col;
+                    draw(&mut grid, child_row, cc, false, false, left, right);
                 }
             }
         }
-
-        // Fill horizontal lines from left to first bracket character
-        let fill_to = chars
-            .iter()
-            .position(|&ch| ch == '│' || ch == '┬' || ch == '┘')
-            .unwrap_or(tree_width);
-
-        for ch in chars.iter_mut().take(fill_to) {
-            if *ch == ' ' {
-                *ch = '─';
-            }
-        }
-
-        tree_lines.push(chars.into_iter().collect());
     }
 
+    // Extend each leaf to the left edge. Only draw leftward: the rightward link is
+    // the horizontal connector's job, and adding `right` here would dead-end into
+    // empty space for a leaf whose merge sits in column 0.
+    for &row in orig_to_row.iter() {
+        draw(&mut grid, row, 0, false, false, true, false);
+    }
+
+    // Soften the L-corners to rounded glyphs for a nicer dendrogram. Junction
+    // merging above uses the sharp forms; round only at the end. T-junctions and
+    // crosses have no rounded Unicode variants, so they stay square.
+    let tree_lines: Vec<String> = grid
+        .into_iter()
+        .map(|r| r.into_iter().map(round_corner).collect())
+        .collect();
+
     (tree_lines, tree_width)
+}
+
+/// Map the four sharp box-drawing corners to their rounded Unicode equivalents.
+fn round_corner(c: char) -> char {
+    match c {
+        '┌' => '╭',
+        '┐' => '╮',
+        '┘' => '╯',
+        '└' => '╰',
+        other => other,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Helper: build a byte sequence from a string literal.
+    fn seq(s: &str) -> Vec<u8> {
+        s.as_bytes().to_vec()
+    }
+
+    /// Helper: standard gap LUT for '-' and '.'.
+    fn gaps() -> [bool; 256] {
+        build_gap_lut(&['-', '.'])
+    }
+
+    fn decode(c: char) -> (bool, bool, bool, bool) {
+        match c {
+            '╵' => (true, false, false, false),
+            '╷' => (false, true, false, false),
+            '╴' => (false, false, true, false),
+            '╶' => (false, false, false, true),
+            '─' => (false, false, true, true),
+            '│' => (true, true, false, false),
+            '┌' | '╭' => (false, true, false, true),
+            '┐' | '╮' => (false, true, true, false),
+            '└' | '╰' => (true, false, false, true),
+            '┘' | '╯' => (true, false, true, false),
+            '├' => (true, true, false, true),
+            '┤' => (true, true, true, false),
+            '┬' => (false, true, true, true),
+            '┴' => (true, false, true, true),
+            '┼' => (true, true, true, true),
+            _ => (false, false, false, false),
+        }
+    }
+
+    /// Count grid cells whose connection points at a neighbor that does not connect
+    /// back (a "dead-end" stub). Leftward connections at column 0 reach the display
+    /// edge and are allowed.
+    fn count_dead_ends(tree_lines: &[String], width: usize) -> usize {
+        let grid: Vec<Vec<char>> = tree_lines.iter().map(|l| l.chars().collect()).collect();
+        let h = grid.len();
+        let mut dead = 0;
+        for row in 0..h {
+            for col in 0..width {
+                let (u, d, l, ri) = decode(grid[row][col]);
+                if ri && (col + 1 >= width || !decode(grid[row][col + 1]).2) {
+                    dead += 1;
+                }
+                if l && col > 0 && !decode(grid[row][col - 1]).3 {
+                    dead += 1;
+                }
+                if u && (row == 0 || !decode(grid[row - 1][col]).1) {
+                    dead += 1;
+                }
+                if d && (row + 1 >= h || !decode(grid[row + 1][col]).0) {
+                    dead += 1;
+                }
+            }
+        }
+        dead
+    }
+
+    #[test]
+    fn test_dendrogram_has_no_dead_ends() {
+        // Regression: every drawn segment must connect to a neighbor — no orphan
+        // "starter branch" stubs. Exercised on the real r-scape alignment, whose
+        // dissimilarity ties previously produced spurious ┤ / ┬ stubs.
+        let path = std::path::Path::new("examples/r-scape/RF00005.sto");
+        let Ok(aln) = crate::stockholm::parser::parse_file(path) else {
+            return; // example not present in this environment; skip
+        };
+        let seqs: Vec<Vec<u8>> = aln
+            .sequences
+            .iter()
+            .map(|s| s.data().into_bytes())
+            .collect();
+        let r = cluster_sequences_with_tree(&seqs, &gaps());
+        assert_eq!(
+            count_dead_ends(&r.tree_lines, r.tree_width),
+            0,
+            "dendrogram contains dead-end stubs"
+        );
+    }
+
     #[test]
     fn test_hamming_distance_identical() {
-        let seq1: Vec<char> = "ACGU".chars().collect();
-        let seq2: Vec<char> = "ACGU".chars().collect();
-        let gaps = vec!['-', '.'];
-        assert_eq!(hamming_distance(&seq1, &seq2, &gaps), 0);
+        let seq1 = seq("ACGU");
+        let seq2 = seq("ACGU");
+        assert_eq!(hamming_distance(&seq1, &seq2, &gaps()), 0);
     }
 
     #[test]
     fn test_hamming_distance_different() {
-        let seq1: Vec<char> = "ACGU".chars().collect();
-        let seq2: Vec<char> = "UGCA".chars().collect();
-        let gaps = vec!['-', '.'];
-        assert_eq!(hamming_distance(&seq1, &seq2, &gaps), 4);
+        let seq1 = seq("ACGU");
+        let seq2 = seq("UGCA");
+        assert_eq!(hamming_distance(&seq1, &seq2, &gaps()), 4);
     }
 
     #[test]
     fn test_hamming_distance_with_gaps() {
-        let seq1: Vec<char> = "AC-U".chars().collect();
-        let seq2: Vec<char> = "AC-U".chars().collect();
-        let gaps = vec!['-', '.'];
-        assert_eq!(hamming_distance(&seq1, &seq2, &gaps), 0);
+        let seq1 = seq("AC-U");
+        let seq2 = seq("AC-U");
+        assert_eq!(hamming_distance(&seq1, &seq2, &gaps()), 0);
 
-        let seq3: Vec<char> = "ACGU".chars().collect();
-        assert_eq!(hamming_distance(&seq1, &seq3, &gaps), 1); // gap vs G
+        let seq3 = seq("ACGU");
+        assert_eq!(hamming_distance(&seq1, &seq3, &gaps()), 1); // gap vs G
     }
 
     #[test]
     fn test_hamming_distance_case_insensitive() {
-        let seq1: Vec<char> = "acgu".chars().collect();
-        let seq2: Vec<char> = "ACGU".chars().collect();
-        let gaps = vec!['-', '.'];
-        assert_eq!(hamming_distance(&seq1, &seq2, &gaps), 0);
+        let seq1 = seq("acgu");
+        let seq2 = seq("ACGU");
+        assert_eq!(hamming_distance(&seq1, &seq2, &gaps()), 0);
     }
 
     #[test]
     fn test_cluster_single_sequence() {
-        let sequences = vec!["ACGU".chars().collect()];
-        let gaps = vec!['-', '.'];
-        let order = cluster_sequences(&sequences, &gaps);
+        let sequences = vec![seq("ACGU")];
+        let order = cluster_sequences(&sequences, &gaps());
         assert_eq!(order, vec![0]);
     }
 
     #[test]
     fn test_cluster_two_sequences() {
-        let sequences = vec!["ACGU".chars().collect(), "ACGU".chars().collect()];
-        let gaps = vec!['-', '.'];
-        let order = cluster_sequences(&sequences, &gaps);
+        let sequences = vec![seq("ACGU"), seq("ACGU")];
+        let order = cluster_sequences(&sequences, &gaps());
         assert_eq!(order.len(), 2);
         assert!(order.contains(&0));
         assert!(order.contains(&1));
@@ -402,13 +598,8 @@ mod tests {
     #[test]
     fn test_cluster_groups_similar() {
         // Sequences 0 and 1 are identical, sequence 2 is different
-        let sequences = vec![
-            "AAAA".chars().collect(),
-            "AAAA".chars().collect(),
-            "UUUU".chars().collect(),
-        ];
-        let gaps = vec!['-', '.'];
-        let order = cluster_sequences(&sequences, &gaps);
+        let sequences = vec![seq("AAAA"), seq("AAAA"), seq("UUUU")];
+        let order = cluster_sequences(&sequences, &gaps());
 
         // Check that 0 and 1 are adjacent in the order
         let pos0 = order.iter().position(|&x| x == 0).unwrap();
@@ -422,14 +613,8 @@ mod tests {
     #[test]
     fn test_tree_rendering() {
         // Test with 4 sequences: 0,1 similar, 2,3 similar
-        let sequences = vec![
-            "AAAA".chars().collect(),
-            "AAAG".chars().collect(),
-            "UUUU".chars().collect(),
-            "UUUG".chars().collect(),
-        ];
-        let gaps = vec!['-', '.'];
-        let result = cluster_sequences_with_tree(&sequences, &gaps);
+        let sequences = vec![seq("AAAA"), seq("AAAG"), seq("UUUU"), seq("UUUG")];
+        let result = cluster_sequences_with_tree(&sequences, &gaps());
 
         // Check we got 4 tree lines
         assert_eq!(result.tree_lines.len(), 4);
@@ -438,7 +623,57 @@ mod tests {
         // Check each line contains expected dendrogram characters
         for line in &result.tree_lines {
             assert!(
-                line.chars().all(|c| "─┬┘│ ".contains(c)),
+                line.chars().all(|c| "─│┌┐└┘├┤┬┴┼╭╮╯╰╷╵╴╶ ".contains(c)),
+                "Tree line '{}' contains unexpected characters",
+                line
+            );
+        }
+    }
+
+    #[test]
+    fn test_tree_column_reflects_merge_height() {
+        // Four sequences forming two tight pairs that merge at low height, with the
+        // two pairs joined at the root at high height. The pair-merge columns must be
+        // strictly less than the root-merge column (column reflects merge height).
+        let sequences = vec![
+            seq("AAAAAAAA"),
+            seq("AAAAAAAG"), // pair with 0
+            seq("UUUUUUUU"),
+            seq("UUUUUUUG"), // pair with 2
+        ];
+        let gap_lut = gaps();
+        let n = sequences.len();
+
+        let mut distances = compute_distance_matrix(&sequences, &gap_lut);
+        let dend = linkage(&mut distances, n, Method::Average);
+        let steps = dend.steps();
+
+        // Three steps: two pair merges (low diss) then the root merge (max diss).
+        let max_diss = steps.last().unwrap().dissimilarity;
+        assert!(max_diss > 0.0);
+        let tree_width = 32.min((n - 1).max(1));
+
+        let col_of = |diss: f64| ((diss / max_diss) * (tree_width - 1) as f64).round() as usize;
+
+        // The last step is the root; the first two are the tight pair merges.
+        let root_col = col_of(steps[2].dissimilarity);
+        let pair0_col = col_of(steps[0].dissimilarity);
+        let pair1_col = col_of(steps[1].dissimilarity);
+
+        assert!(
+            pair0_col < root_col,
+            "pair merge column {pair0_col} should be < root column {root_col}"
+        );
+        assert!(
+            pair1_col < root_col,
+            "pair merge column {pair1_col} should be < root column {root_col}"
+        );
+
+        // And the rendered tree uses only box-drawing characters.
+        let result = cluster_sequences_with_tree(&sequences, &gap_lut);
+        for line in &result.tree_lines {
+            assert!(
+                line.chars().all(|c| "─│┌┐└┘├┤┬┴┼╭╮╯╰╷╵╴╶ ".contains(c)),
                 "Tree line '{}' contains unexpected characters",
                 line
             );
@@ -447,9 +682,8 @@ mod tests {
 
     #[test]
     fn test_tree_rendering_single() {
-        let sequences = vec!["ACGU".chars().collect()];
-        let gaps = vec!['-', '.'];
-        let result = cluster_sequences_with_tree(&sequences, &gaps);
+        let sequences = vec![seq("ACGU")];
+        let result = cluster_sequences_with_tree(&sequences, &gaps());
 
         assert_eq!(result.tree_lines.len(), 1);
         assert_eq!(result.tree_width, 1);
@@ -460,14 +694,13 @@ mod tests {
     fn test_cluster_with_collapse_groups() {
         // Test clustering with precomputed collapse groups
         // Sequences: A, A, B, A, C (indices 0-4, where 0,1,3 are identical "A")
-        let sequences: Vec<Vec<char>> = vec![
-            "AAAA".chars().collect(), // 0 - A
-            "AAAA".chars().collect(), // 1 - A (duplicate)
-            "CCCC".chars().collect(), // 2 - B
-            "AAAA".chars().collect(), // 3 - A (duplicate)
-            "UUUU".chars().collect(), // 4 - C
+        let sequences: Vec<Vec<u8>> = vec![
+            seq("AAAA"), // 0 - A
+            seq("AAAA"), // 1 - A (duplicate)
+            seq("CCCC"), // 2 - B
+            seq("AAAA"), // 3 - A (duplicate)
+            seq("UUUU"), // 4 - C
         ];
-        let gaps = vec!['-', '.'];
 
         // Collapse groups: (representative, all_members)
         let collapse_groups = vec![
@@ -476,7 +709,7 @@ mod tests {
             (4, vec![4]),       // C appears once
         ];
 
-        let result = cluster_sequences_with_collapse(&sequences, &gaps, &collapse_groups);
+        let result = cluster_sequences_with_collapse(&sequences, &gaps(), &collapse_groups);
 
         // Should have all 5 sequences in order
         assert_eq!(result.order.len(), 5);
@@ -501,15 +734,10 @@ mod tests {
     #[test]
     fn test_cluster_with_collapse_all_identical() {
         // Edge case: all sequences identical
-        let sequences: Vec<Vec<char>> = vec![
-            "AAAA".chars().collect(),
-            "AAAA".chars().collect(),
-            "AAAA".chars().collect(),
-        ];
-        let gaps = vec!['-', '.'];
+        let sequences: Vec<Vec<u8>> = vec![seq("AAAA"), seq("AAAA"), seq("AAAA")];
         let collapse_groups = vec![(0, vec![0, 1, 2])];
 
-        let result = cluster_sequences_with_collapse(&sequences, &gaps, &collapse_groups);
+        let result = cluster_sequences_with_collapse(&sequences, &gaps(), &collapse_groups);
 
         assert_eq!(result.order.len(), 3);
         assert_eq!(result.tree_lines.len(), 3);
@@ -521,13 +749,12 @@ mod tests {
         // 0 and 2 are similar (AAAA vs AAAG), 1 and 3 are similar (UUUU vs UUUG)
         // Original order [0, 1, 2, 3] should become something like [0, 2, 1, 3] or [1, 3, 0, 2]
         let sequences = vec![
-            "AAAA".chars().collect(), // 0 - similar to 2
-            "UUUU".chars().collect(), // 1 - similar to 3
-            "AAAG".chars().collect(), // 2 - similar to 0
-            "UUUG".chars().collect(), // 3 - similar to 1
+            seq("AAAA"), // 0 - similar to 2
+            seq("UUUU"), // 1 - similar to 3
+            seq("AAAG"), // 2 - similar to 0
+            seq("UUUG"), // 3 - similar to 1
         ];
-        let gaps = vec!['-', '.'];
-        let order = cluster_sequences(&sequences, &gaps);
+        let order = cluster_sequences(&sequences, &gaps());
 
         // Order should NOT be [0,1,2,3] - similar sequences should be adjacent
         assert_ne!(
@@ -562,13 +789,12 @@ mod tests {
     fn test_cluster_protein_sequences() {
         // Test with protein-like sequences to ensure clustering works for non-RNA
         let sequences = vec![
-            "MKTL".chars().collect(), // 0 - similar to 2
-            "WFGH".chars().collect(), // 1 - similar to 3
-            "MKTV".chars().collect(), // 2 - similar to 0
-            "WFGI".chars().collect(), // 3 - similar to 1
+            seq("MKTL"), // 0 - similar to 2
+            seq("WFGH"), // 1 - similar to 3
+            seq("MKTV"), // 2 - similar to 0
+            seq("WFGI"), // 3 - similar to 1
         ];
-        let gaps = vec!['-', '.'];
-        let order = cluster_sequences(&sequences, &gaps);
+        let order = cluster_sequences(&sequences, &gaps());
 
         // Similar sequences should be adjacent
         let pos0 = order.iter().position(|&x| x == 0).unwrap();
@@ -590,18 +816,12 @@ mod tests {
     fn test_cluster_all_unique_sequences() {
         // Test when all sequences are unique (common for protein alignments)
         // This tests the code path where num_unique == n
-        let sequences = vec![
-            "AAAA".chars().collect(),
-            "CCCC".chars().collect(),
-            "GGGG".chars().collect(),
-            "UUUU".chars().collect(),
-        ];
-        let gaps = vec!['-', '.'];
+        let sequences = vec![seq("AAAA"), seq("CCCC"), seq("GGGG"), seq("UUUU")];
 
         // Create collapse groups where each sequence is its own group
         let collapse_groups = vec![(0, vec![0]), (1, vec![1]), (2, vec![2]), (3, vec![3])];
 
-        let result = cluster_sequences_with_collapse(&sequences, &gaps, &collapse_groups);
+        let result = cluster_sequences_with_collapse(&sequences, &gaps(), &collapse_groups);
 
         // Should still produce a valid ordering with all 4 sequences
         assert_eq!(result.order.len(), 4);
@@ -609,5 +829,30 @@ mod tests {
         assert!(result.order.contains(&1));
         assert!(result.order.contains(&2));
         assert!(result.order.contains(&3));
+    }
+
+    #[test]
+    fn test_large_alignment_still_builds_tree() {
+        // Regression: large alignments must still produce a full, non-empty tree
+        // (one line per row) so the dendrogram renders for real-world sizes.
+        let n = 200;
+        let sequences: Vec<Vec<u8>> = (0..n)
+            .map(|i| format!("{:08b}", i % 256).into_bytes())
+            .collect();
+        let collapse_groups: Vec<(usize, Vec<usize>)> = (0..n).map(|i| (i, vec![i])).collect();
+
+        let result = cluster_sequences_with_collapse(&sequences, &gaps(), &collapse_groups);
+
+        assert_eq!(result.order.len(), n);
+        assert_eq!(
+            result.tree_lines.len(),
+            n,
+            "tree must have one line per row"
+        );
+        assert!(
+            result.tree_lines.iter().all(|l| !l.is_empty()),
+            "no tree line should be empty for a large alignment"
+        );
+        assert!(result.tree_width >= 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,6 +291,11 @@ fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App)
             }
         }
 
+        // Advance any background clustering job (animate spinner / apply result).
+        // The 100ms poll above returns immediately on input, so this still runs
+        // frequently enough to animate the spinner even when the user is idle.
+        app.poll_clustering();
+
         if app.should_quit {
             return Ok(());
         }


### PR DESCRIPTION
## Summary

Clustering a ~950-sequence alignment (`examples/r-scape/RF00005.sto`, 954 seqs, 953 unique) took several seconds and froze the TUI, and the rendered dendrogram was garbled. This reworks the whole clustering path — speed, responsiveness, and drawing.

## Speed
- Rewrote the distance path on **bytes** with an O(1) `[bool;256]` gap lookup table (was `Vec<char>` + a linear `gap_chars.contains` scan **twice per cell**).
- **Parallelized** the pairwise distance matrix with `rayon`, preserving kodama's condensed row-major layout exactly.

## Responsiveness
- Interactive `:cluster` now runs on a **background thread**, delivering the result over an `mpsc` channel. `poll_clustering()` (called each event-loop tick) animates a braille spinner and applies the result when ready.
- A second `:cluster` / mutating edit is blocked with "Clustering in progress…" while one runs; navigation stays live. CLI-startup and post-paste re-clusters stay synchronous.

## Dendrogram
Rewrote `build_tree_chars` as a correct rotated dendrogram, then fixed a series of drawing issues surfaced in review:
- **Height-scaled columns** — each merge's column scales with its dissimilarity (root at far right), instead of the old merge-creation-order collapse.
- **Real corners** — faithful half-line (`╷ ╵ ╴ ╶`) + junction composition so corners actually form; softened to rounded `╭ ╮ ╯ ╰`. (T-junctions/crosses have no rounded Unicode variant, so they stay square.)
- **No dead-end stubs** — eliminated the "starter branch" orphans caused by same-column ties and the leaf-edge stub.
- **Pairs point toward their parent** — a 2-leaf clade spans two adjacent rows (no cell between them, a grid limitation), so its join attaches on the side facing its parent rather than always the bottom.
- **No size cap** — the tree is always built and shown by default at any alignment size (dropped `TREE_MAX_SEQS`); `:tree` toggles it.

## Dependency
Adds `rayon` (parallel distance matrix). Everything else uses `std`.

## Tests
- Distance/cluster fixtures converted to bytes.
- New coverage: merge-height column ordering, large-alignment tree building, and a **no-dead-ends invariant** verified on the full RF00005 tree.
- `cargo build` / `cargo clippy --all-features -- -D warnings` / `cargo fmt --all --check` / `cargo test` (55) all clean.

## Verification (manual, needs a real terminal)
`cargo run --release -- examples/r-scape/RF00005.sto` → `:cluster` completes in well under a second with an animated spinner and a responsive UI; the dendrogram renders as a clean rounded tree with pairs pointing toward their parents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)